### PR TITLE
Put stuff in subcommands

### DIFF
--- a/cmd/nvccmd/create.go
+++ b/cmd/nvccmd/create.go
@@ -1,4 +1,4 @@
-package cmd
+package nvccmd
 
 import (
 	"errors"

--- a/cmd/nvccmd/extract.go
+++ b/cmd/nvccmd/extract.go
@@ -1,4 +1,4 @@
-package cmd
+package nvccmd
 
 import (
 	"bufio"

--- a/cmd/nvccmd/list.go
+++ b/cmd/nvccmd/list.go
@@ -1,4 +1,4 @@
-package cmd
+package nvccmd
 
 import (
 	"fmt"

--- a/cmd/nvccmd/nvccmd.go
+++ b/cmd/nvccmd/nvccmd.go
@@ -1,0 +1,21 @@
+package nvccmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var nvcCmd = &cobra.Command{
+	Use:   "nvc",
+	Short: "Manipulate nvc files",
+}
+
+func init() {
+	nvcCmd.AddCommand(listCmd)
+	nvcCmd.AddCommand(extractCmd())
+	nvcCmd.AddCommand(pathlistCmd)
+	nvcCmd.AddCommand(createCommand())
+}
+
+func Cmd() *cobra.Command {
+	return nvcCmd
+}

--- a/cmd/nvccmd/pathlist.go
+++ b/cmd/nvccmd/pathlist.go
@@ -1,4 +1,4 @@
-package cmd
+package nvccmd
 
 import (
 	"bufio"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sector-f/jhmod/cmd/nvccmd"
 	"github.com/spf13/cobra"
 )
 
@@ -14,10 +15,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(listCmd)
-	rootCmd.AddCommand(extractCmd())
-	rootCmd.AddCommand(pathlistCmd)
-	rootCmd.AddCommand(createCommand())
+	rootCmd.AddCommand(nvccmd.Cmd())
 	rootCmd.AddCommand(saveCmd)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/sector-f/jhmod/cmd/nvccmd"
+	"github.com/sector-f/jhmod/cmd/savecmd"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +17,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(nvccmd.Cmd())
-	rootCmd.AddCommand(saveCmd)
+	rootCmd.AddCommand(savecmd.Cmd())
 }
 
 func Execute() {

--- a/cmd/savecmd/save.go
+++ b/cmd/savecmd/save.go
@@ -1,4 +1,4 @@
-package cmd
+package savecmd
 
 import (
 	"fmt"
@@ -55,4 +55,8 @@ func saveInfoCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolP("debug", "d", false, "Show more internal state of the tool.")
 
 	return cmd
+}
+
+func Cmd() *cobra.Command {
+	return saveCmd
 }


### PR DESCRIPTION
This PR moves all the nvc subcommands into their own package (`nvccmd`) + subcommand (`jhmod nvc`)
It also moves the save command into its own package just for consistency 