### PR TITLE
nix: move to flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /jhmod
 
+# Nix build output symlink
+/result
+
 # Discourage accidental staging of scratch files used by the tool.
 core.*
 core

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
           pkgs = nixpkgsFor.${system};
         in
         {
-          go-hello = pkgs.buildGoModule {
+          jhmod = pkgs.buildGoModule {
             pname = "jhmod";
             inherit version;
             # In 'nix develop', we don't need a copy of the source tree
@@ -55,7 +55,7 @@
       # The default package for 'nix build'. This makes sense if the
       # flake provides only one package or there is a clear "main"
       # package.
-      defaultPackage = forAllSystems (system: self.packages.${system}.go-hello);
+      defaultPackage = forAllSystems (system: self.packages.${system}.jhmod);
       devShells = forAllSystems (system:
         let pkgs = nixpkgsFor.${system};
         in {
@@ -63,5 +63,11 @@
             buildInputs = with pkgs; [ go gopls gotools go-tools shellcheck ];
           };
         });
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.jhmod}/bin/jhmod";
+        };
+      });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "A tool to work with Jupiter Hell game files";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "nixpkgs/nixos-21.11";
+
+  outputs = { self, nixpkgs }:
+    let
+
+      # to work with older version of flakes
+      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+
+      # Generate a user-friendly version number.
+      version = builtins.substring 0 8 lastModifiedDate;
+
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+
+    in
+    {
+
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          go-hello = pkgs.buildGoModule {
+            pname = "jhmod";
+            inherit version;
+            # In 'nix develop', we don't need a copy of the source tree
+            # in the Nix store.
+            src = ./.;
+
+            # This hash locks the dependencies of this package. It is
+            # necessary because of how Go requires network access to resolve
+            # VCS.  See https://www.tweag.io/blog/2021-03-04-gomod2nix/ for
+            # details. Normally one can build with a fake sha256 and rely on native Go
+            # mechanisms to tell you what the hash should be or determine what
+            # it should be "out-of-band" with other tooling (eg. gomod2nix).
+            # To begin with it is recommended to set this, but one must
+            # remeber to bump this hash when your dependencies change.
+            #vendorSha256 = pkgs.lib.fakeSha256;
+
+            vendorSha256 = "sha256-ox631K0cq0GtaEPI+Vy+hy2KE8NC773npQjJuEyMy/A=";
+          };
+        });
+
+      # The default package for 'nix build'. This makes sense if the
+      # flake provides only one package or there is a clear "main"
+      # package.
+      defaultPackage = forAllSystems (system: self.packages.${system}.go-hello);
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system};
+        in {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [ go gopls gotools go-tools shellcheck ];
+          };
+        });
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,0 @@
-with import <nixpkgs> {};
-
-stdenv.mkDerivation {
-  name = "jhmod";
-  buildInputs = [
-    go_1_18
-    shellcheck
-  ];
-}


### PR DESCRIPTION
This offers the following improvements:

- `nix build` builds jhmod on nix
- `nix run` runs the jhmod program from a fresh checkout
- `nix develop` opens a development environment
- One can reference the flake from their nix configuration to install jhmod directly from this repo (using the `flake.nix`)